### PR TITLE
Fix issues with electron versions and non-working host changer

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "test": "react-scripts test --env=jsdom"
   },
   "devDependencies": {
-    "electron": "^1.6.0"
+    "electron": "=1.6.0"
   }
 }

--- a/src/actions/creators.js
+++ b/src/actions/creators.js
@@ -9,7 +9,7 @@ export const URL = {
   }),
 
   changeHost: (host) => ({
-    type: t.URL.PORT_CHANGED,
+    type: t.URL.HOST_CHANGED,
     host,
   }),
 };


### PR DESCRIPTION
1. Fix electron<->grpc compatibility issues by locking the exact version of electron instead of the compatible with that exact version
2. Fix url host could not be changed due to wrong action type

Closes #9 